### PR TITLE
Update class-wc-geolocation-based-products-frontend.php

### DIFF
--- a/includes/class-wc-geolocation-based-products-frontend.php
+++ b/includes/class-wc-geolocation-based-products-frontend.php
@@ -172,7 +172,7 @@ class WC_Geolocation_Based_Products_Frontend {
 									unset( $products[ $key ] );
 								}
 							}
-						} else {
+						} /*else {
 							foreach( $row['product_categories'] as $cat ) {
 								$product_cats[] = $cat;
 							}
@@ -180,7 +180,7 @@ class WC_Geolocation_Based_Products_Frontend {
 							foreach( $row['products'] as $product ) {
 								$products[] = $product;
 							}
-						}
+						}*/
 					} elseif ( 'hide' === $row['show_hide'] && $this->location_matched( $row['country'], $row['region'], $row['city'] ) ) {
 						foreach( $row['product_categories'] as $cat ) {
 							$product_cats[] = $cat;


### PR DESCRIPTION
This logic created an issue for me and I wondered if it even makes sense to have this logic in place here. I may not be understanding how to properly implement it, but for me the use of the "Show" option is used to reverse a previous option that I had created to "Hide" a certain product category.

My options are as follows:
For all regions -> Hide "Carolinas" product category
For "FL" region -> Hide "National" product category
For "FL" region -> Show "Carolinas" product category
For "NC" region -> Hide "National" product category
For "NC" region -> Show "Carolinas" product category

I'm in FL and I tested your logic. The lines I propose removing caused the option 'For "NC" region -> Show "Carolinas" product category' to actually "Hide" the "Carolinas" product category for me in FL.

Will the "Show" option ever be used for anything besides showing a previously hidden product category or product?
